### PR TITLE
Enable playback commands outside of Editor mode, and extend functionality

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -124,7 +124,7 @@ export default class TimestampPlugin extends Plugin {
 		this.addCommand({
 			id: 'toggle-play-pause-video',
 			name: 'Toggle play/pause video',
-			editorCallback: (editor: Editor, view: MarkdownView) => {
+			callback: () => {
 				this.setPlaying(!this.player.props.playing)
 			}
 		});
@@ -133,7 +133,7 @@ export default class TimestampPlugin extends Plugin {
 		this.addCommand({
 			id: 'seek-forward',
 			name: 'Seek Forward',
-			editorCallback: (editor: Editor, view: MarkdownView) => {
+			callback: () => {
 				if (this.player) this.player.seekTo(this.player.getCurrentTime() + parseInt(this.settings.forwardSeek));
 			}
 		});
@@ -142,7 +142,7 @@ export default class TimestampPlugin extends Plugin {
 		this.addCommand({
 			id: 'seek-backward',
 			name: 'Seek Backward',
-			editorCallback: (editor: Editor, view: MarkdownView) => {
+			callback: () => {
 				if (this.player) this.player.seekTo(this.player.getCurrentTime() - parseInt(this.settings.backwardsSeek));
 			}
 		});

--- a/main.ts
+++ b/main.ts
@@ -138,6 +138,15 @@ export default class TimestampPlugin extends Plugin {
 			}
 		});
 
+		//Command that pauses the video
+		this.addCommand({
+			id: 'pause-video',
+			name: 'Pause video',
+			callback: () => {
+				this.setPlaying(false)
+			}
+		});
+
 		// Seek forward by set amount of seconds
 		this.addCommand({
 			id: 'seek-forward',

--- a/main.ts
+++ b/main.ts
@@ -129,6 +129,15 @@ export default class TimestampPlugin extends Plugin {
 			}
 		});
 
+		//Command that plays the video
+		this.addCommand({
+			id: 'play-video',
+			name: 'Play video',
+			callback: () => {
+				this.setPlaying(true)
+			}
+		});
+
 		// Seek forward by set amount of seconds
 		this.addCommand({
 			id: 'seek-forward',

--- a/main.ts
+++ b/main.ts
@@ -122,8 +122,8 @@ export default class TimestampPlugin extends Plugin {
 
 		//Command that play/pauses the video
 		this.addCommand({
-			id: 'pause-player',
-			name: 'Pause player',
+			id: 'toggle-play-pause-video',
+			name: 'Toggle play/pause video',
 			editorCallback: (editor: Editor, view: MarkdownView) => {
 				this.setPlaying(!this.player.props.playing)
 			}

--- a/main.ts
+++ b/main.ts
@@ -150,7 +150,7 @@ export default class TimestampPlugin extends Plugin {
 		// Seek forward by set amount of seconds
 		this.addCommand({
 			id: 'seek-forward',
-			name: 'Seek Forward',
+			name: 'Seek forward',
 			callback: () => {
 				if (this.player) this.player.seekTo(this.player.getCurrentTime() + parseInt(this.settings.forwardSeek));
 			}
@@ -159,7 +159,7 @@ export default class TimestampPlugin extends Plugin {
 		// Seek backwards by set amount of seconds
 		this.addCommand({
 			id: 'seek-backward',
-			name: 'Seek Backward',
+			name: 'Seek backward',
 			callback: () => {
 				if (this.player) this.player.seekTo(this.player.getCurrentTime() - parseInt(this.settings.backwardsSeek));
 			}


### PR DESCRIPTION
# Summary
I wanted to be able to use commands to control the player in `reading` mode, as well as the `editor` modes.

# Overview
1. Switched `play-pause`, `seek-forward`, and `seek-backward` commands from using `editorCallback` to `callback` method
2. Renamed the existing `play-pause` (Pause player) command to `toggle-play-pause-video` (Toggle play/pause video)
3. Enforced sentence case for command names `seek-forward` (now "Seek forward") and `seek-backward` (now "Seek backwards")
4. Added new `play-video` (Play video), and `pause-video` (Pause video) commands